### PR TITLE
Support for OpenTelemetry - distributed tracing context propagation via Nats.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,8 @@ jobs:
           name: Pull smile commons code
           command: |
               export SMILE_COMMONS_VERSION=$(grep 'smile_commons\.version' pom.xml | head -1 | sed 's/<smile_commons\.version>//g' | sed 's|</smile_commons\.version>||' | tr -d '[:blank:]' | cut -f1) && \
-              export SMILE_COMMONS_ORG=$(grep 'smile_commons\.group' pom.xml | head -1 | sed 's/<smile_commons\.group>//g' | sed 's|</smile_commons\.group>||' | tr -d '[:blank:]' | cut -d. -f3) && \
               cd .. && \
-              git clone https://github.com/$SMILE_COMMONS_ORG/smile-commons.git && \
+              git clone https://github.com/mskcc/smile-commons.git && \
               cd smile-commons && \
               git fetch --tags && \
               git checkout ${SMILE_COMMONS_VERSION}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.mskcc.cmo</groupId>
   <artifactId>smile-messaging-java</artifactId>
   <name>CMO SMILE Messaging Library</name>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <description>master maven module</description>
   <packaging>jar</packaging>
   <parent>
@@ -21,7 +21,7 @@
     <jackson.version>2.11.2</jackson.version>
     <!-- smile common centralized config properties -->
     <smile_commons.group>com.github.mskcc</smile_commons.group>
-    <smile_commons.version>1.3.6.RELEASE</smile_commons.version>
+    <smile_commons.version>1.3.7.RELEASE</smile_commons.version>
   </properties>
 
   <repositories>

--- a/src/main/java/org/mskcc/cmo/messaging/Gateway.java
+++ b/src/main/java/org/mskcc/cmo/messaging/Gateway.java
@@ -1,6 +1,7 @@
 package org.mskcc.cmo.messaging;
 
 import io.nats.client.Message;
+import org.mskcc.smile.commons.OpenTelemetryUtils.TraceMetadata;
 
 public interface Gateway {
 
@@ -10,17 +11,19 @@ public interface Gateway {
 
     boolean isConnected();
 
+    void publishWithTrace(String subject, Object message, TraceMetadata tmd) throws Exception;
+
     void publish(String subject, Object message) throws Exception;
-    
+
     void publish(String msgId, String subject, Object message) throws Exception;
 
     void subscribe(String subject, Class messageClass,
             MessageConsumer messageConsumer) throws Exception;
-    
+
     Message request(String subject, String message) throws Exception;
-    
+
     void replySub(String subject, MessageConsumer consumer) throws Exception;
-    
+
     void replyPublish(String subject, Object message) throws Exception;
 
     void shutdown() throws Exception;


### PR DESCRIPTION
Added publish method which accepts TraceMetadata.  For this code to work in production, the commons library dependency needs to be upgraded to support the OpenTelemetryUtils addition. 