### PR TITLE
Remove unused file system logger file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
       <version>0.4.0</version>
     </dependency>
     <!-- smile commons -->
-    <dependency>
-      <groupId>${smile_commons.group}</groupId>
-      <artifactId>smile-commons</artifactId>
-      <version>${smile_commons.version}</version>
-    </dependency>
     <!-- jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Nothing and no one uses this. 

Note that while the runtime dependencies no longer requires `smile-commons`, it is still required during build as defined in the `pom.xml` -> `<build>` section